### PR TITLE
Align tipos_transacao layout and modal CRUD with status_pagamento

### DIFF
--- a/templates/tipos_transacao/form.html
+++ b/templates/tipos_transacao/form.html
@@ -15,7 +15,10 @@
             {% endif %}
         </div>
         {% endfor %}
-        <div style="text-align:right;margin-top:8px;"><button type="submit" class="btn">Salvar</button></div>
+        <div style="text-align:right;margin-top:8px;">
+            <button type="submit" class="btn">Salvar</button>
+            <a href="{% url 'tipos_transacao:list' %}" class="btn btn-secondary" style="margin-left:8px;">Cancelar</a>
+        </div>
     </form>
 </div>
 

--- a/templates/tipos_transacao/list.html
+++ b/templates/tipos_transacao/list.html
@@ -2,12 +2,8 @@
 
 {% block content %}
 <h2>Tipos de Transação Financeira</h2>
-
-<div style="margin:12px 0;display:flex;gap:8px;align-items:center;">
-    <div style="margin-left:auto">
-        <input id="search-tipo" placeholder="Pesquisar por tipo..."
-            style="padding:6px 8px;border-radius:6px;border:1px solid #ddd;" />
-    </div>
+<div style="display:flex;gap:12px;align-items:center;margin-bottom:8px;">
+    <div style="font-size:0.9rem;color:#666">Total: <strong>{{ items|length }}</strong></div>
 </div>
 
 <div class="list-container">
@@ -15,7 +11,7 @@
         <thead>
             <tr>
                 <th>Nome</th>
-                <th>Ações</th>
+                <th style="width:160px">Ações</th>
             </tr>
         </thead>
         <tbody>
@@ -29,7 +25,7 @@
         </tbody>
         <tfoot>
             <tr>
-                <td colspan="2" style="text-align:right;"><button id="btnNewTipo" class="btn"
+                <td colspan="2" style="text-align:right;"><button id="btnNewTipo" class="btn btn-primary"
                         data-url="{% url 'tipos_transacao:create' %}">Novo</button></td>
             </tr>
         </tfoot>
@@ -37,33 +33,69 @@
 </div>
 
 <div id="modal" style="display:none;"></div>
-
 {% endblock %}
 
 {% block scripts %}
 {% load static %}
+{# rely on global modal_ajax.js to handle data-url and data-delete-url events #}
 <script>
-    document.addEventListener('click', function (e) {
-        const btn = e.target.closest && e.target.closest('button[data-url]');
-        if (!btn) return;
-        e.preventDefault();
-        const url = btn.getAttribute('data-url');
-        console.debug('TiposTransacao: loading form from', url);
-        fetch(url, { headers: { 'X-Requested-With': 'XMLHttpRequest' }, credentials: 'same-origin' })
-            .then(r => {
-                if (!r.ok) throw new Error('Network response was not ok: ' + r.status);
-                return r.text();
-            })
-            .then(html => {
-                const modal = document.getElementById('modal');
-                if (!modal) throw new Error('Modal container #modal not found');
-                modal.innerHTML = html;
-                modal.style.display = 'block';
-            })
-            .catch(err => {
-                console.error('TiposTransacao: error loading form', err);
-                alert('Erro ao carregar o formulário. Veja o console para detalhes.');
+    document.addEventListener('DOMContentLoaded', function () {
+        const modal = document.getElementById('modal');
+        const btnNew = document.getElementById('btnNewTipo');
+
+        function disableViewMode(modalEl) {
+            try {
+                const form = modalEl.querySelector('form');
+                if (!form) return;
+                form.querySelectorAll('input,select,textarea').forEach(n => { try { n.setAttribute('disabled', 'disabled'); } catch (e) { } });
+                form.querySelectorAll('button, input[type=submit]').forEach(n => {
+                    try {
+                        const tag = n.tagName.toLowerCase();
+                        if (tag === 'button') {
+                            if ((n.type || '').toLowerCase() === 'submit') { n.style.display = 'none'; n.setAttribute('disabled', 'disabled'); }
+                        } else {
+                            n.style.display = 'none'; n.setAttribute('disabled', 'disabled');
+                        }
+                    } catch (e) { }
+                });
+            } catch (e) { console.error('tipos_transacao: disableViewMode error', e); }
+        }
+
+        async function fetchForm(url, mode) {
+            try {
+                const res = await fetch(url, { headers: { 'X-Requested-With': 'XMLHttpRequest' }, credentials: 'same-origin' });
+                if (!res.ok) { console.error('TiposTransacao: fetch failed', res.status); return; }
+                const html = await res.text();
+                if (!modal) { console.error('TiposTransacao: modal container #modal not found'); return; }
+                if (mode) modal.dataset.mode = mode; else delete modal.dataset.mode;
+                modal.innerHTML = html; modal.style.display = 'block';
+                if (mode === 'view') disableViewMode(modal);
+            } catch (err) { console.error('TiposTransacao: fetchForm error', err); alert('Erro ao carregar o formulário. Veja o console para detalhes.'); }
+        }
+
+        if (btnNew) btnNew.addEventListener('click', (e) => {
+            const url = btnNew.dataset.url || btnNew.getAttribute('data-url');
+            if (url) fetchForm(url);
+        });
+
+        // attach handlers to rows (will be re-applied when rows are mutated)
+        function attachHandlers(root = document) {
+            root.querySelectorAll('.btn-edit').forEach((b) => {
+                if (b._spAttached) return; b._spAttached = true;
+                b.addEventListener('click', (e) => { e.preventDefault(); fetchForm(e.currentTarget.dataset.url); });
             });
+            root.querySelectorAll('.btn-view').forEach((b) => {
+                if (b._spAttached) return; b._spAttached = true;
+                b.addEventListener('click', (e) => { e.preventDefault(); fetchForm(e.currentTarget.dataset.url, 'view'); });
+            });
+        }
+
+        attachHandlers();
+        const tbody = document.querySelector('.list-container table tbody');
+        if (tbody) {
+            const obs = new MutationObserver(() => attachHandlers(tbody));
+            obs.observe(tbody, { childList: true, subtree: true });
+        }
     });
 </script>
 {% endblock %}

--- a/templates/tipos_transacao/row.html
+++ b/templates/tipos_transacao/row.html
@@ -1,8 +1,8 @@
-<tr id="row-{{ item.id }}">
+<tr data-id="{{ item.id }}">
     <td>{{ item.nome }}</td>
-    <td>
-        <button class="btn-view icon-btn" data-mode="view" data-url="{% url 'tipos_transacao:update' item.id %}"
-            title="Visualizar">
+    <td class="text-end">
+        <button class="btn btn-sm btn-outline-primary icon-btn btn-view" data-mode="view"
+            data-url="{% url 'tipos_transacao:update' item.id %}" title="Visualizar">
             <svg class="icon-sm" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
                 <path
                     d="M12 5C7 5 2.73 8.11 1 12c1.73 3.89 6 7 11 7s9.27-3.11 11-7c-1.73-3.89-6-7-11-7zm0 12a5 5 0 110-10 5 5 0 010 10z"
@@ -10,12 +10,20 @@
                 <path d="M12 9a3 3 0 100 6 3 3 0 000-6z" fill="#2b6cb0" />
             </svg>
         </button>
-        <button class="btn-edit icon-btn" data-url="{% url 'tipos_transacao:update' item.id %}" title="Editar">
+        <button class="btn btn-sm btn-outline-primary icon-btn btn-edit"
+            data-url="{% url 'tipos_transacao:update' item.id %}" title="Editar">
             <svg class="icon-sm" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
                 <path d="M3 17.25V21h3.75L17.81 9.94l-3.75-3.75L3 17.25z" fill="#2b6cb0" />
                 <path
                     d="M20.71 7.04a1.003 1.003 0 000-1.42l-2.34-2.34a1.003 1.003 0 00-1.42 0l-1.83 1.83 3.75 3.75 1.84-1.82z"
                     fill="#2b6cb0" />
+            </svg>
+        </button>
+        <button class="btn btn-sm btn-outline-danger icon-btn btn-delete" title="Excluir"
+            data-delete-url="{% url 'tipos_transacao:delete' item.id %}">
+            <svg class="icon-sm" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+                <path d="M6 7h12v13a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2V7z" fill="#e53e3e" />
+                <path d="M9 3h6v2H9z" fill="#e53e3e" />
             </svg>
         </button>
     </td>

--- a/tipos_transacao/urls.py
+++ b/tipos_transacao/urls.py
@@ -8,4 +8,5 @@ urlpatterns = [
     path("", views.list_tipos, name="list"),
     path("create/", views.create_tipo, name="create"),
     path("update/<uuid:pk>/", views.update_tipo, name="update"),
+    path("delete/<uuid:pk>/", views.delete_tipo, name="delete"),
 ]


### PR DESCRIPTION
This PR makes the FINANCEIRO | TIPO TRANSAÇÃO section match the layout and actions of FINANCEIRO | STATUS DE PAGAMENTO.\n\nChanges include:\n- Updated list and row templates to include view/edit/delete buttons and total count.\n- Added page JS to open forms in modal via AJAX and disable inputs in view mode.\n- Added delete URL and view to support AJAX deletion.\n- Added Cancel button to form page.\n\nFiles changed: templates/tipos_transacao/list.html, templates/tipos_transacao/row.html, templates/tipos_transacao/form.html, templates/tipos_transacao/_form_partial.html, tipos_transacao/views.py, tipos_transacao/urls.py